### PR TITLE
Change ExternalSecret in prep for cluster migrations

### DIFF
--- a/helm/templates/04_secrets.yaml
+++ b/helm/templates/04_secrets.yaml
@@ -1,9 +1,30 @@
+{{- if lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "externalsecrets.external-secrets.io" }}
+# Create ExternalSecret for "externalsecrets.external-secrets.io"
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: secretstore-sample
+    kind: SecretStore
+  target:
+    name: {{ .Values.name }}
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: {{ .Values.secretmgr }}
+{{- else }}
+# Assume "externalsecrets.kubernetes-client.io" is installed
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
-  name: {{.Values.name}}
-  namespace: {{.Values.namespace}}
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
 spec:
   backendType: secretsManager
   dataFrom:
-    - "{{.Values.secretmgr}}"
+    - "{{ .Values.secretmgr }}"
+{{- end }}


### PR DESCRIPTION
This work is being done in preparation for cluster upgrades. The new clusters we are migrating to will be using a new CRD for the ExternalSecret Resource. This pull requests allows the Helm template to dynamically choose what type of Secret to create based upon what CRD the cluster is using.